### PR TITLE
fix(db): drizzle config must not require the whole app environment

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,29 +1,33 @@
 import type { Config } from 'drizzle-kit'
-// drizzle requires the ts extension to import config.
-import { config } from './src/config.ts'
-import { logger } from './src/helpers/index.ts'
 
-logger.info({
-  msg: 'drizzle config loaded',
-  dialect: 'postgresql',
-  schema: './src/schema.ts',
-  env: config.env,
-})
+// Deliberately does NOT import ./src/config.ts. drizzle-kit loads this file
+// for `migrate`/`generate`, and the app config validates the WHOLE runtime
+// environment (Supabase URL and keys, etc.). A migration job legitimately
+// has only database credentials, so importing it made `pnpm migrate` fail
+// with "Configuration validation failed" in CI — migrations are a deploy
+// step, not an app boot.
+const url = process.env.DATABASE_URL
+
+const dbCredentials = url
+  ? { url }
+  : {
+      host: process.env.POSTGRES_HOST ?? 'localhost',
+      user: process.env.POSTGRES_USER ?? 'postgres',
+      port: Number(process.env.POSTGRES_PORT ?? 5432),
+      password: process.env.POSTGRES_PASSWORD ?? 'postgres',
+      database: process.env.POSTGRES_DB ?? 'postgres',
+      ssl: process.env.NODE_ENV === 'production',
+    }
+
+if (!url && !process.env.POSTGRES_HOST) {
+  throw new Error(
+    'drizzle-kit needs DATABASE_URL, or the POSTGRES_* variables, to reach the database'
+  )
+}
 
 export default {
   dialect: 'postgresql',
   schema: './src/schema.ts',
   out: './drizzle',
-  dbCredentials: process.env.DATABASE_URL
-    ? {
-        url: process.env.DATABASE_URL,
-      }
-    : {
-        host: config.db_host,
-        user: config.db_user,
-        port: config.db_port,
-        password: config.db_password,
-        database: config.db_name,
-        ssl: config.env !== 'development',
-      },
+  dbCredentials,
 } satisfies Config


### PR DESCRIPTION
`migrate-dev` went red on main immediately after #134.

`pnpm migrate` → `drizzle-kit migrate` loads `drizzle.config.ts`, which imported `./src/config.ts`. That module validates the **entire** runtime environment (Supabase URL, publishable key, and so on). The migration job supplies only `DATABASE_URL`, so validation failed and no migration could run: `Configuration validation failed. Check environment variables.`

Migrations are a deploy step, not an app boot — they need database credentials, nothing else. The config now reads those directly from the environment and throws a message naming exactly what's missing if neither `DATABASE_URL` nor the `POSTGRES_*` set is present.

**Verified**: `pnpm migrate` against a real Postgres container with `DATABASE_URL` as the only variable set — the same shape the CI job uses — applies migrations successfully.

Side effect: `drizzle.config.ts` no longer logs at import time, which also removes the last of the config-logging that Copilot flagged on #134.