### PR TITLE
ci: verify migrations against a fresh Postgres; retire the dead dev-migrate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,25 @@ jobs:
       - run: pnpm run build
       - run: pnpm run test
 
-  # Run database migrations for development environment
-  migrate-dev:
+  # Prove the migration chain applies cleanly FROM EMPTY, against a fresh
+  # throwaway Postgres. This is verification, not deployment: it catches a
+  # broken or conflicting migration before anything real is touched. It
+  # needs no secrets, so it also works on forks.
+  verify-migrations:
     needs: test-and-build
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: volta-cli/action@v4
@@ -36,10 +51,32 @@ jobs:
       - run: volta install pnpm
       - run: pnpm install
 
-      - name: Run database migrations
+      - name: Apply migrations to a fresh database
         env:
-          DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         run: pnpm migrate
+
+  # Applying migrations to a REAL environment on merge (the Laravel-style
+  # deploy step) lives here when there is an environment to apply them to.
+  # The previous dev job pointed at a Supabase project that has since been
+  # torn down, so it could only ever fail — and a permanently red main
+  # teaches everyone to ignore CI. Re-enable with the environment's URL in
+  # DEV_DATABASE_URL, or fold it into the release-gated deploy.
+  #
+  # migrate-dev:
+  #   needs: verify-migrations
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: volta-cli/action@v4
+  #       with:
+  #         node-version: 22
+  #     - run: volta install pnpm
+  #     - run: pnpm install
+  #     - name: Run database migrations
+  #       env:
+  #         DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+  #       run: pnpm migrate
 
   # TODO uncomment the deployment step when you have configured the secrets.
   # deploy-dev:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,3 +21,38 @@ jobs:
       - run: pnpm run tsc:check
       - run: pnpm run build
       - run: pnpm run test
+
+  # NOTE: intentionally duplicated in main.yml — this copy gates the
+  # merge (which is the one that matters); that copy also covers a direct
+  # push to main. Keep them in step if either changes.
+  # Prove the migration chain applies cleanly FROM EMPTY, against a fresh
+  # throwaway Postgres. This is verification, not deployment: it catches a
+  # broken or conflicting migration before anything real is touched. It
+  # needs no secrets, so it also works on forks.
+  verify-migrations:
+    needs: test-and-build
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: volta-cli/action@v4
+        with:
+          node-version: 22
+      - run: volta install pnpm
+      - run: pnpm install
+
+      - name: Apply migrations to a fresh database
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+        run: pnpm migrate


### PR DESCRIPTION
`migrate-dev` has been failing on main since the dev Supabase project was torn down — it points at `DEV_DATABASE_URL`, which no longer resolves to anything. A job that can never pass is worse than no job: it trains everyone to ignore a red main.

It also conflated two different things:

| | needs | purpose |
|---|---|---|
| **Verify** migrations | a throwaway database | proves the chain applies **from empty** — catches a broken or conflicting migration before it touches anything real |
| **Deploy** migrations | the real database | the Laravel-style apply-on-merge step |

Only the deploy half existed, so a bad migration was discovered by breaking the environment.

**This PR adds the missing half**: `verify-migrations` runs `pnpm migrate` against an ephemeral `postgres:17-alpine` service container — a fresh instance per run, no secrets, so it works on forks too.

**And retires the dead half** — commented rather than deleted, with the exact conditions to bring it back (set `DEV_DATABASE_URL` to a live environment, or fold it into the release-gated deploy). The intent is still valid; there's just nothing to deploy to right now.