### PR TITLE
fix(db,ci,docs): address Copilot review on #138 and #139

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Apply migrations to a fresh database
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
         run: pnpm migrate
 
   # Applying migrations to a REAL environment on merge (the Laravel-style

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,5 +54,5 @@ jobs:
 
       - name: Apply migrations to a fresh database
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
         run: pnpm migrate

--- a/README.md
+++ b/README.md
@@ -627,10 +627,23 @@ see the [documentation for more information](https://supabase.com/docs/reference
 
 ## CI/CD Database Migrations
 
-The project includes automated database migrations that run on:
+Two different jobs, often confused:
 
-- **Development**: When merging to `main` branch
-- **Production**: When creating a GitHub release
+**Verification (active).** `verify-migrations` runs on every pull request
+and on pushes to `main`. It applies the full migration chain to a throwaway
+`postgres:17-alpine` service container — a fresh database per run, starting
+from empty. It needs no secrets, so it also runs on forks. This is what
+catches a broken or conflicting migration *before* it reaches anything real.
+
+**Deployment (currently disabled).** Applying migrations to a real
+environment on merge — the "migrate on deploy" step — is commented out in
+`.github/workflows/main.yml`. It pointed at a Supabase dev project that has
+since been torn down, so it could only fail, and a permanently red `main`
+teaches everyone to ignore CI. Re-enable it by setting `DEV_DATABASE_URL` to
+a live environment and uncommenting the `migrate-dev` job.
+
+**Production**: still runs on creating a GitHub release (`release.yml`,
+using `PROD_DATABASE_URL`).
 
 ### Setup GitHub Secrets
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -6,28 +6,52 @@ import type { Config } from 'drizzle-kit'
 // has only database credentials, so importing it made `pnpm migrate` fail
 // with "Configuration validation failed" in CI — migrations are a deploy
 // step, not an app boot.
-const url = process.env.DATABASE_URL
 
-const dbCredentials = url
-  ? { url }
-  : {
-      host: process.env.POSTGRES_HOST ?? 'localhost',
-      user: process.env.POSTGRES_USER ?? 'postgres',
-      port: Number(process.env.POSTGRES_PORT ?? 5432),
-      password: process.env.POSTGRES_PASSWORD ?? 'postgres',
-      database: process.env.POSTGRES_DB ?? 'postgres',
-      ssl: process.env.NODE_ENV === 'production',
-    }
+const isProduction = process.env.NODE_ENV === 'production'
 
-if (!url && !process.env.POSTGRES_HOST) {
-  throw new Error(
-    'drizzle-kit needs DATABASE_URL, or the POSTGRES_* variables, to reach the database'
-  )
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(
+      `drizzle-kit needs DATABASE_URL, or all of POSTGRES_HOST/PORT/USER/PASSWORD/DB. Missing: ${name}`
+    )
+  }
+  return value
+}
+
+function port(): number {
+  const raw = process.env.POSTGRES_PORT ?? '5432'
+  const parsed = Number(raw)
+  // Number('') is 0 and Number('abc') is NaN; both would surface later as a
+  // baffling connection failure rather than a config error.
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`POSTGRES_PORT must be a port number, got "${raw}"`)
+  }
+  return parsed
+}
+
+function credentials() {
+  const url = process.env.DATABASE_URL
+  if (url) return { url }
+
+  return {
+    host: requireEnv('POSTGRES_HOST'),
+    user: requireEnv('POSTGRES_USER'),
+    port: port(),
+    // Never defaulted. A silent fallback to "postgres" would let a
+    // production migration run against whatever that happens to reach,
+    // and it contradicts src/config.ts, which requires this in production.
+    password: isProduction
+      ? requireEnv('POSTGRES_PASSWORD')
+      : (process.env.POSTGRES_PASSWORD ?? 'postgres'),
+    database: requireEnv('POSTGRES_DB'),
+    ssl: isProduction,
+  }
 }
 
 export default {
   dialect: 'postgresql',
   schema: './src/schema.ts',
   out: './drizzle',
-  dbCredentials,
+  dbCredentials: credentials(),
 } satisfies Config

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -9,18 +9,29 @@ import type { Config } from 'drizzle-kit'
 
 const isProduction = process.env.NODE_ENV === 'production'
 
-function requireEnv(name: string): string {
+// An empty string is treated as unset throughout: `POSTGRES_PASSWORD=""`
+// is a misconfiguration, not a real empty password, and letting it through
+// produces a confusing auth failure instead of a config error.
+function env(name: string): string | undefined {
   const value = process.env[name]
+  return value === undefined || value === '' ? undefined : value
+}
+
+function requireEnv(name: string): string {
+  const value = env(name)
   if (!value) {
+    // Names only what is genuinely required: PORT has a sensible default
+    // and PASSWORD is required in production only, so listing them here
+    // would misdirect someone who is already troubleshooting.
     throw new Error(
-      `drizzle-kit needs DATABASE_URL, or all of POSTGRES_HOST/PORT/USER/PASSWORD/DB. Missing: ${name}`
+      `drizzle-kit needs DATABASE_URL, or POSTGRES_HOST/USER/DB (plus POSTGRES_PASSWORD in production). Missing: ${name}`
     )
   }
   return value
 }
 
 function port(): number {
-  const raw = process.env.POSTGRES_PORT ?? '5432'
+  const raw = env('POSTGRES_PORT') ?? '5432'
   const parsed = Number(raw)
   // Number('') is 0 and Number('abc') is NaN; both would surface later as a
   // baffling connection failure rather than a config error.
@@ -31,7 +42,7 @@ function port(): number {
 }
 
 function credentials() {
-  const url = process.env.DATABASE_URL
+  const url = env('DATABASE_URL')
   if (url) return { url }
 
   return {
@@ -43,7 +54,7 @@ function credentials() {
     // and it contradicts src/config.ts, which requires this in production.
     password: isProduction
       ? requireEnv('POSTGRES_PASSWORD')
-      : (process.env.POSTGRES_PASSWORD ?? 'postgres'),
+      : (env('POSTGRES_PASSWORD') ?? 'postgres'),
     database: requireEnv('POSTGRES_DB'),
     ssl: isProduction,
   }


### PR DESCRIPTION
Copilot reviewed both of the last two PRs and I merged them without checking. Addressing all three findings.

**1. Weak production default (in my own #138 code).** `drizzle.config.ts` silently defaulted `POSTGRES_PASSWORD` to `postgres` — in production too. A migration could have run against whatever that happened to reach, and it directly contradicted `src/config.ts`, which requires the password in production. It is now required there and never defaulted.

**2. Port coercion.** `Number(POSTGRES_PORT)` gives `0` for an empty string and `NaN` for junk, which surfaces much later as a confusing connection failure rather than a config error. Now validated as a real port, with the bad value quoted in the message.

**3. The error now names what's missing**, which is what #138's description claimed but the code didn't do.

**4. URL scheme.** Workflows used `postgres://` while the docs use `postgresql://`. Aligned on the canonical one.

**5. Stale docs.** The README still said `migrate-dev` runs on merge and needs `DEV_DATABASE_URL` — untrue since #139. It now separates **verification** (active: ephemeral container, every PR, no secrets) from **deployment migration** (disabled, with the exact conditions to re-enable), and notes production still migrates on release.

**Verified:** applies migrations with only `DATABASE_URL` set, and throws `Missing: POSTGRES_HOST` from a genuinely empty environment.