### PR TITLE
fix: startup check rejects path-level public route declarations

### DIFF
--- a/src/helpers/permissions.startup-guard.test.ts
+++ b/src/helpers/permissions.startup-guard.test.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import type { NextFunction, Request, Response } from 'express'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildRouterApp } from '@/test-support/route-app.ts'
 import {
   assertAllRoutesHavePermissions,
@@ -139,6 +139,10 @@ describe('assertAllRoutesHavePermissions', () => {
 })
 
 describe('the real application route set', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   // Every test above builds a synthetic app, so all of them passed while the actual app could not
   // start: the guard demanded a per-method permission, but `/`, `/login` and `/signup` are declared
   // public at the path level (`{ permissions: {}, authenticated: false }`), so it named all three as
@@ -147,11 +151,10 @@ describe('the real application route set', () => {
   it('starts up clean, so a route or permission change cannot break boot without failing here first', async () => {
     // The route modules pull in config.ts, which validates the whole runtime env at module load.
     // These values are never used — nothing here opens a connection — they just let the import
-    // succeed so the real route table can be registered.
-    Object.assign(process.env, {
-      SUPABASE_URL: 'https://startup-guard-test.supabase.co',
-      SUPABASE_PUBLISHABLE_KEY: 'not-used',
-    })
+    // succeed so the real route table can be registered. Stubbed rather than assigned so they are
+    // undone afterwards and no later test inherits them.
+    vi.stubEnv('SUPABASE_URL', 'https://startup-guard-test.supabase.co')
+    vi.stubEnv('SUPABASE_PUBLISHABLE_KEY', 'not-used')
 
     const { routes } = await import('@/routes/index.ts')
     const { adminRoutes } = await import('@/routes/admin.ts')

--- a/src/helpers/permissions.startup-guard.test.ts
+++ b/src/helpers/permissions.startup-guard.test.ts
@@ -1,5 +1,6 @@
+import express from 'express'
 import type { NextFunction, Request, Response } from 'express'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { buildRouterApp } from '@/test-support/route-app.ts'
 import {
   assertAllRoutesHavePermissions,
@@ -16,6 +17,12 @@ const isAuthorized = markAsAuthorizationGuard(
   (_req: Request, _res: Response, next: NextFunction): void => next()
 )
 const otherMiddleware = (_req: Request, _res: Response, next: NextFunction): void => next()
+
+// Importing the real route table (see the last describe block) reaches the db module, which opens
+// a Postgres connection at import time and calls process.exit(1) if it fails. Reading the router
+// needs no database, so the connection is stubbed out rather than making route wiring untestable
+// without live infrastructure.
+vi.mock('@/services/db/drizzle.ts', () => ({ db: {} }))
 
 describe('assertAllRoutesHavePermissions', () => {
   it('reports a registered route missing a permissions entry, naming the (path, method) pair', () => {
@@ -78,9 +85,10 @@ describe('assertAllRoutesHavePermissions', () => {
     )
   })
 
-  it('does not throw for the real, fully-registered app route set', () => {
-    // Sanity check: build the real routes exactly as server.ts does and confirm the guard is
-    // satisfied — proves the guard isn't just permissive by construction.
+  it('does not throw when every registered method has a permissions entry', () => {
+    // Named for what it actually covers. It used to claim it built "the real routes exactly as
+    // server.ts does", which it never did — it wires three paths by hand. The real route set is
+    // exercised in the describe block below.
     const app = buildRouterApp([
       { method: 'get', path: '/workspaces/:id', middleware: [isAuthorized] },
       { method: 'patch', path: '/workspaces/:id', middleware: [isAuthorized] },
@@ -127,5 +135,40 @@ describe('assertAllRoutesHavePermissions', () => {
     expect(() => assertAllRoutesHavePermissions(app, permissions)).toThrow(
       /DELETE \/__another-unregistered-route/
     )
+  })
+})
+
+describe('the real application route set', () => {
+  // Every test above builds a synthetic app, so all of them passed while the actual app could not
+  // start: the guard demanded a per-method permission, but `/`, `/login` and `/signup` are declared
+  // public at the path level (`{ permissions: {}, authenticated: false }`), so it named all three as
+  // undeclared and threw. Registering the REAL routes is the only assertion that could have caught
+  // it — a synthetic app can only prove the guard agrees with the fixture it was handed.
+  it('starts up clean, so a route or permission change cannot break boot without failing here first', async () => {
+    // The route modules pull in config.ts, which validates the whole runtime env at module load.
+    // These values are never used — nothing here opens a connection — they just let the import
+    // succeed so the real route table can be registered.
+    Object.assign(process.env, {
+      SUPABASE_URL: 'https://startup-guard-test.supabase.co',
+      SUPABASE_PUBLISHABLE_KEY: 'not-used',
+    })
+
+    const { routes } = await import('@/routes/index.ts')
+    const { adminRoutes } = await import('@/routes/admin.ts')
+    const app = express()
+    routes(app)
+    adminRoutes(app)
+
+    expect(() => assertAllRoutesHavePermissions(app, permissions)).not.toThrow()
+  })
+
+  it('declares the public routes as public rather than as merely unlisted', () => {
+    // Guards the distinction the bug turned on. An empty `permissions` object is not the same as a
+    // missing entry: the first is a decision (no auth required on this path), the second is an
+    // oversight that must fail closed. If these entries were deleted, the routes would keep working
+    // — the guard skips them either way — but would become unauthenticated by accident.
+    for (const path of ['/', '/login', '/signup'] as const) {
+      expect(permissions.get(path)?.authenticated).toBe(false)
+    }
   })
 })

--- a/src/helpers/permissions.ts
+++ b/src/helpers/permissions.ts
@@ -220,6 +220,19 @@ function isAuthorizationGuard(fn: unknown): boolean {
 }
 
 /**
+ * A route is deliberately public when it has an entry saying so. `authenticated` is a property of
+ * the path, not of a method — isAuthenticated.ts looks the entry up by route key alone — so such an
+ * entry decides every method on that path and needs no per-method permission.
+ *
+ * Both the runtime check (isAuthorized.ts) and the startup guard below read this, so the two can't
+ * drift on what "decided" means. They already did once: the guard demanded a per-method entry, so
+ * the three public routes were reported as undeclared and startup threw.
+ */
+export function isExplicitlyPublicRoute(entry: ResourceWithMeta | undefined): boolean {
+  return entry !== undefined && !entry.authenticated
+}
+
+/**
  * Find every (path, method) pair that is actually wired through the isAuthorized middleware —
  * ie. a real, registered business route — but has no matching permissions entry. Comparing two
  * hand-maintained lists (the old approach) can't catch a route registered with a literal string,
@@ -248,6 +261,8 @@ export function findRoutesMissingPermissions(
 
     for (const method of methods) {
       const entry = permissionsMap.get(route.path as Route)
+      if (isExplicitlyPublicRoute(entry)) continue
+
       const hasMethodPermission =
         entry !== undefined &&
         Object.prototype.hasOwnProperty.call(entry.permissions, method as string)

--- a/src/middleware/isAuthorized.ts
+++ b/src/middleware/isAuthorized.ts
@@ -3,7 +3,12 @@ import { getProfileById } from '@/handlers/profiles/profiles.methods.ts'
 import { HttpErrors, HttpStatusCode } from '@/helpers/Http.ts'
 import type { Route } from '@/helpers/index.ts'
 import { logger, permissions } from '@/helpers/index.ts'
-import { markAsAuthorizationGuard, ROLES, type Method } from '@/helpers/permissions.ts'
+import {
+  isExplicitlyPublicRoute,
+  markAsAuthorizationGuard,
+  ROLES,
+  type Method,
+} from '@/helpers/permissions.ts'
 import { apiResponse } from '@/helpers/response.ts'
 import { accounts } from '@/schema.ts'
 import { db } from '@/services/db/drizzle.ts'
@@ -123,7 +128,7 @@ export const isAuthorized = markAsAuthorizationGuard(
       // Fail closed: a route with no permissions entry defaults to requiring authentication.
       const requiresAuth = resourcePermissions ? resourcePermissions.authenticated : true
       // A route is genuinely public only if it has an explicit entry saying so (root, login, signup).
-      const isPublicRoute = resourcePermissions !== undefined && !requiresAuth
+      const isPublicRoute = isExplicitlyPublicRoute(resourcePermissions)
 
       logger.debug(
         { requestId: req.id, method: req.method, path: req.path, accountId, workspaceId },


### PR DESCRIPTION
## What

The startup route check requires a **per-method** permissions entry, but the three public routes (`/`, `/login`, `/signup`) are declared at the **path** level as `{ permissions: {}, authenticated: false }`. The check reported all three as undeclared and threw:

```
Error: Routes registered without a matching permissions entry: GET /, POST /login, POST /signup
```

`main` does not start. Reproduced by building and running the server on `main` before this branch, and confirmed fixed after.

## Why it happened

`authenticated` is a property of the path — `isAuthenticated` looks the entry up by route key alone — so a path-level entry already decides every method on it. `isAuthorized` encoded that correctly (`isPublicRoute`); the startup check encoded it differently. Two definitions of "declared", one of them wrong.

Both now call a single `isExplicitlyPublicRoute` helper, so they cannot drift again.

## Why the tests missed it

Every test in the startup-check suite builds a synthetic app from a hand-written route list, so they only ever proved the check agrees with the fixture it was handed. This adds one that registers the **real** route table and asserts the check passes — the only assertion that could have caught this. One existing test was named "the real, fully-registered app route set" while wiring three paths by hand; renamed to what it actually covers.

## Verification

- Full suite: 34 passed. Typecheck, lint, format, build clean.
- Built and ran the server: `[server]: Server is running on port: 4000` (the DB connection error after it is expected — no local Postgres).
- Reverted the fix → the new test fails.
- Flipped `/login` to `authenticated: true` → it is reported again, so the skip stays narrow and an undeclared route still fails startup.